### PR TITLE
warp7: Add support to UpdateHub

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -72,3 +72,10 @@ MACHINEOVERRIDES_prepend_apalis-imx6 = "updatehub-imx:"
 IMAGE_BOOT_FILES_updatehub-imx_apalis-imx6 ??= "bootscript-apalis-imx6;boot.scr"
 WKS_FILES_updatehub-imx_apalis-imx6 ??= "updatehub.imx.wks"
 WKS_FILE_DEPENDS_updatehub-imx_apalis-imx6 ??= "u-boot-script-toradex-updatehub"
+
+
+###
+# Configuration for Element14/NXP devices
+#
+MACHINEOVERRIDES_prepend_imx7s-warp = "updatehub-imx:"
+WKS_FILES_updatehub-imx_imx7s-warp ??= "updatehub.imx-uboot.wks"

--- a/recipes-bsp/u-boot/u-boot-fslc-fw-utils/imx7s-warp/fw_env.config
+++ b/recipes-bsp/u-boot/u-boot-fslc-fw-utils/imx7s-warp/fw_env.config
@@ -1,0 +1,4 @@
+# WaRP7 i.MX7
+
+# Block device name	Device offset	Env. size
+/dev/mmcblk2 0x80000 0x2000

--- a/recipes-bsp/u-boot/u-boot-fslc/0001-UpdateHub-Add-common-header.patch
+++ b/recipes-bsp/u-boot/u-boot-fslc/0001-UpdateHub-Add-common-header.patch
@@ -1,7 +1,7 @@
 From f2056ea1343ab38387c7256f60175b86d548e20c Mon Sep 17 00:00:00 2001
 From: Otavio Salvador <otavio@ossystems.com.br>
 Date: Wed, 14 Jun 2017 12:21:16 -0300
-Subject: [PATCH 1/3] UpdateHub: Add common header
+Subject: [PATCH 1/4] UpdateHub: Add common header
 Organization: O.S. Systems Software LTDA.
 
 Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>

--- a/recipes-bsp/u-boot/u-boot-fslc/0002-mx6sabre_common-Add-support-to-UpdateHub.patch
+++ b/recipes-bsp/u-boot/u-boot-fslc/0002-mx6sabre_common-Add-support-to-UpdateHub.patch
@@ -1,7 +1,7 @@
 From b6ab903e95867039babeeea5c9fc0a2a0c498273 Mon Sep 17 00:00:00 2001
 From: Fabio Berton <fabio.berton@ossystems.com.br>
 Date: Fri, 4 Aug 2017 17:36:45 -0300
-Subject: [PATCH 2/3] mx6sabre_common: Add support to UpdateHub
+Subject: [PATCH 2/4] mx6sabre_common: Add support to UpdateHub
 Organization: O.S. Systems Software LTDA.
 
 Set all variables needed to use UpdateHub tool.

--- a/recipes-bsp/u-boot/u-boot-fslc/0003-wandboard-Add-support-to-UpdateHub.patch
+++ b/recipes-bsp/u-boot/u-boot-fslc/0003-wandboard-Add-support-to-UpdateHub.patch
@@ -1,7 +1,7 @@
 From 7ffe81889d7117901d30b133bc3f127f601273f7 Mon Sep 17 00:00:00 2001
 From: Fabio Berton <fabio.berton@ossystems.com.br>
 Date: Mon, 7 Aug 2017 10:30:34 -0300
-Subject: [PATCH 3/3] wandboard: Add support to UpdateHub
+Subject: [PATCH 3/4] wandboard: Add support to UpdateHub
 Organization: O.S. Systems Software LTDA.
 
 Set all variables needed to use UpdateHub tool.

--- a/recipes-bsp/u-boot/u-boot-fslc/0004-warp7-Add-support-to-UpdateHub.patch
+++ b/recipes-bsp/u-boot/u-boot-fslc/0004-warp7-Add-support-to-UpdateHub.patch
@@ -1,0 +1,60 @@
+From 3a23484c6744b80070ea2bf5044ae75a517cbff3 Mon Sep 17 00:00:00 2001
+From: Pierre-Jean TEXIER <texier.pj2@gmail.com>
+Date: Tue, 20 Mar 2018 22:56:09 +0100
+Subject: [PATCH 4/4] warp7: Add support to UpdateHub
+
+Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>
+---
+ include/configs/warp7.h | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/include/configs/warp7.h b/include/configs/warp7.h
+index 11f1bc3..000168f 100644
+--- a/include/configs/warp7.h
++++ b/include/configs/warp7.h
+@@ -79,6 +79,42 @@
+ 		   "fi; " \
+ 	   "fi"
+ 
++#undef CONFIG_BOOTCOMMAND
++
++/*
++ * UpdateHub configuration
++ */
++
++#define CONFIG_BOOTCOUNT_ENV
++
++/* Environment */
++#define UPDATEHUB_LOAD_OS_A     "load mmc 0:1 ${loadaddr} /boot/${image}; " \
++                                "load mmc 0:1 ${fdt_addr} /boot/${fdt_file}; "
++#define UPDATEHUB_FIND_ROOT_A   "part uuid mmc 0:1 uuid"
++
++#define UPDATEHUB_LOAD_OS_B     "load mmc 0:2 ${loadaddr} /boot/${image}; " \
++                                "load mmc 0:2 ${fdt_addr} /boot/${fdt_file}; "
++#define UPDATEHUB_FIND_ROOT_B   "part uuid mmc 0:2 uuid"
++
++#define UPDATEHUB_BOOTARGS      "root=PARTUUID=${uuid} rootfstype=ext4 " \
++                                "rootwait rw console=${console},${baudrate} "
++#define UPDATEHUB_BOOTCMD		"bootz ${loadaddr} - ${fdt_addr}"
++
++#include <configs/updatehub-common.h>
++
++#undef CONFIG_EXTRA_ENV_SETTINGS
++#define CONFIG_EXTRA_ENV_SETTINGS \
++	CONFIG_DFU_ENV_SETTINGS \
++	"image=zImage\0" \
++	"console=ttymxc0\0" \
++	"ethact=usb_ether\0" \
++	"fdt_high=0xffffffff\0" \
++	"initrd_high=0xffffffff\0" \
++	"fdt_file=imx7s-warp.dtb\0" \
++	"fdt_addr=0x83000000\0" \
++	"ip_dyn=yes\0" \
++	UPDATEHUB_ENV
++
+ #define CONFIG_SYS_MEMTEST_START	0x80000000
+ #define CONFIG_SYS_MEMTEST_END		(CONFIG_SYS_MEMTEST_START + 0x20000000)
+ 
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot-fslc_2017.11.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fslc_2017.11.bbappend
@@ -4,6 +4,7 @@ UPDATEHUB_IMX_PATCHES = " \
     file://0001-UpdateHub-Add-common-header.patch \
     file://0002-mx6sabre_common-Add-support-to-UpdateHub.patch \
     file://0003-wandboard-Add-support-to-UpdateHub.patch \
+    file://0004-warp7-Add-support-to-UpdateHub.patch \
 "
 
 SRC_URI_append_updatehub-imx = " ${UPDATEHUB_IMX_PATCHES}"

--- a/uhu/imx7s-warp.uhupkg.config
+++ b/uhu/imx7s-warp.uhupkg.config
@@ -1,0 +1,31 @@
+{
+    "objects": [
+        [
+            {
+                "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
+                "filesystem": "ext4",
+                "format?": true,
+                "mode": "tarball",
+                "target": "/dev/disk/by-label/system_a",
+                "target-path": "/",
+                "target-type": "device"
+            }
+        ],
+        [
+            {
+                "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
+                "filesystem": "ext4",
+                "format?": true,
+                "mode": "tarball",
+                "target": "/dev/disk/by-label/system_b",
+                "target-path": "/",
+                "target-type": "device"
+            }
+        ]
+    ],
+    "product": "",
+    "supported-hardware": [
+        "$MACHINE"
+    ],
+    "version": null
+}


### PR DESCRIPTION
This is a simple support for WaRP7.

Tested with updatehub-image-minimal and systemd with the following configuration (local.conf):
- UPDATEHUB_ACCESS_ID
- UPDATEHUB_ACCESS_SECRET
- UPDATEHUB_PRODUCT_UID
- UPDATEHUB_UHUPKG_PUBLIC_KEY
- UPDATEHUB_UHUPKG_PRIVATE_KEY