### PR TITLE
uhu: make sure label option exists when formatting

### DIFF
--- a/uhu/apalis-imx6.uhupkg.config
+++ b/uhu/apalis-imx6.uhupkg.config
@@ -14,6 +14,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_a",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_a",
@@ -35,6 +36,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_b",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_b",

--- a/uhu/imx6qdlsabresd.uhupkg.config
+++ b/uhu/imx6qdlsabresd.uhupkg.config
@@ -30,6 +30,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_a",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_a",
@@ -67,6 +68,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_b",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_b",

--- a/uhu/imx7s-warp.uhupkg.config
+++ b/uhu/imx7s-warp.uhupkg.config
@@ -17,6 +17,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_a",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_a",
@@ -41,6 +42,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_b",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_b",

--- a/uhu/nitrogen6x.uhupkg.config
+++ b/uhu/nitrogen6x.uhupkg.config
@@ -14,6 +14,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_a",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_a",
@@ -35,6 +36,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_b",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_b",

--- a/uhu/wandboard.uhupkg.config
+++ b/uhu/wandboard.uhupkg.config
@@ -30,6 +30,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_a",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_a",
@@ -67,6 +68,7 @@
             {
                 "filename": "$IMAGE_BASENAME-$MACHINE.tar.xz",
                 "filesystem": "ext4",
+                "format-options": "-L system_b",
                 "format?": true,
                 "mode": "tarball",
                 "target": "/dev/disk/by-label/system_b",


### PR DESCRIPTION
This fixes the following issue:

transient error: couldn't format '/dev/disk/by-label/system_a'. cmdline error: Error executing command 'mkfs.ext4
-F -L system_a /dev/disk/by-label/system_a': mke2fs 1.43.5 (04-Aug-2017)\n
The file /dev/disk/by-label/system_a does not exist and no size was specified

If the label is not present when formatting the device,
this one does not exists anymore and update fails.

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>