### PR TITLE
bsp/u-boot: set 'updatehub_active' to 0 when we reverting to A

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fslc/0001-UpdateHub-Add-common-header.patch
+++ b/recipes-bsp/u-boot/u-boot-fslc/0001-UpdateHub-Add-common-header.patch
@@ -56,7 +56,7 @@ index 0000000000..a1086aa4c5
 +            "setenv updatehub_active 1; " \
 +        "else " \
 +            "echo Bootcount limit reached. Reverting to image A; " \
-+            "setenv updatehub_active 1; " \
++            "setenv updatehub_active 0; " \
 +        "fi; " \
 +        "setenv upgrade_available 0; " \
 +        "saveenv;\0" \


### PR DESCRIPTION
Without this modification, we always booting with B.

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>