### PR TITLE
Fix imx6qdlsabresd issues, run convert-overrides.py against the layer, support only honister release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,8 +9,8 @@ BBFILE_COLLECTIONS += "updatehub-freescale"
 BBFILE_PATTERN_updatehub-freescale = "^${LAYERDIR}/"
 BBFILE_PRIORITY_updatehub-freescale = "6"
 
-LAYERSERIES_COMPAT_updatehub-freescale = "hardknott"
 LAYERDEPENDS_updatehub-freescale = "updatehub"
+LAYERSERIES_COMPAT_updatehub-freescale = "honister"
 
 
 ###

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,62 +7,62 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "updatehub-freescale"
 BBFILE_PATTERN_updatehub-freescale = "^${LAYERDIR}/"
-BBFILE_PRIORITY_updatehub-freescale = "6"
+BBFILE_PRIORITY:updatehub-freescale = "6"
 
-LAYERDEPENDS_updatehub-freescale = "updatehub"
 LAYERSERIES_COMPAT_updatehub-freescale = "honister"
+LAYERDEPENDS:updatehub-freescale = "updatehub"
 
 
 ###
 # Global setting to use UpadateHub with meta-freescale layer
 #
 # Setting to use wic image
-IMAGE_BOOT_FILES_updatehub-imx ??= ""
-WKS_FILE_DEPENDS_updatehub-imx += "virtual/bootloader"
-IMAGE_FSTYPES_updatehub-imx ??= "tar.xz wic.bmap wic.gz"
-WKS_SEARCH_PATH_updatehub-imx ??= "${THISDIR}:${@':'.join('%s/wic' % p for p in '${BBPATH}'.split(':'))}:${@':'.join('%s/scripts/lib/wic/canned-wks' % l for l in '${BBPATH}:${COREBASE}'.split(':'))}"
+IMAGE_BOOT_FILES:updatehub-imx ??= ""
+WKS_FILE_DEPENDS:updatehub-imx += "virtual/bootloader"
+IMAGE_FSTYPES:updatehub-imx ??= "tar.xz wic.bmap wic.gz"
+WKS_SEARCH_PATH:updatehub-imx ??= "${THISDIR}:${@':'.join('%s/wic' % p for p in '${BBPATH}'.split(':'))}:${@':'.join('%s/scripts/lib/wic/canned-wks' % l for l in '${BBPATH}:${COREBASE}'.split(':'))}"
 
 # UpdateHub settings
-UPDATEHUB_ACTIVE_INACTIVE_BACKEND_updatehub-imx ??= "u-boot"
-UPDATEHUB_DEVICE_IDENTITY_updatehub-imx ??= "primary-iface"
-UPDATEHUB_FILESYSTEM_SUPPORT_updatehub-imx ??= "ext4"
-UPDATEHUB_IMAGE_TYPE_updatehub-imx ??= "active/inactive"
-UPDATEHUB_INSTALL_MODE_updatehub-imx ??= "tarball"
+UPDATEHUB_ACTIVE_INACTIVE_BACKEND:updatehub-imx ??= "u-boot"
+UPDATEHUB_DEVICE_IDENTITY:updatehub-imx ??= "primary-iface"
+UPDATEHUB_FILESYSTEM_SUPPORT:updatehub-imx ??= "ext4"
+UPDATEHUB_IMAGE_TYPE:updatehub-imx ??= "active/inactive"
+UPDATEHUB_INSTALL_MODE:updatehub-imx ??= "tarball"
 
-PREFERRED_RPROVIDER_u-boot-fw-utils_updatehub-imx ??= "libubootenv"
-PREFERRED_PROVIDER_u-boot-default-script_updatehub-imx ??= "u-boot-updatehub-script"
-UPDATEHUB_RUNTIME_PACKAGES_append_updatehub-imx = " u-boot-default-script u-boot-default-env"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS_updatehub-imx += " \
+PREFERRED_RPROVIDER:u-boot-fw-utils:updatehub-imx ??= "libubootenv"
+PREFERRED_PROVIDER:u-boot-default-script:updatehub-imx ??= "u-boot-updatehub-script"
+UPDATEHUB_RUNTIME_PACKAGES:append:updatehub-imx = " u-boot-default-script u-boot-default-env"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS:updatehub-imx += " \
     kernel-image \
     kernel-devicetree \
 "
 
 # Do not change fstab file
-WIC_CREATE_EXTRA_ARGS_updatehub-imx ??= "--no-fstab-update"
+WIC_CREATE_EXTRA_ARGS:updatehub-imx ??= "--no-fstab-update"
 
 ###
 # Configuration for i.MX6 SABRE AUTO and SABRE Smart Device
 #
 # UpdateHub settings for imx6qdlsabresd machine
-MACHINEOVERRIDES_prepend_imx6qdlsabresd = "updatehub-imx:"
-WKS_FILES_updatehub-imx_imx6qdlsabresd ??= "updatehub.imx-uboot-spl-bootpart.wks.in"
-IMAGE_BOOT_FILES_updatehub-imx_imx6qdlsabresd ??= "boot.scr-${MACHINE};boot.scr"
+MACHINEOVERRIDES:prepend:imx6qdlsabresd = "updatehub-imx:"
+WKS_FILES:updatehub-imx:imx6qdlsabresd ??= "updatehub.imx-uboot-spl-bootpart.wks.in"
+IMAGE_BOOT_FILES:updatehub-imx:imx6qdlsabresd ??= "boot.scr-${MACHINE};boot.scr"
 # UpdateHub Bootscript variables for imx6qdlsabresd machine
-UPDATEHUB_BOOTSCRIPT_LOAD_A_updatehub-imx_imx6qdlsabresd ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_A:updatehub-imx:imx6qdlsabresd ??= "\
 load mmc \${mmcdev}:2 \${loadaddr} /boot/\${image}; run findfdt; run video_args_script; \
 load mmc \${mmcdev}:2 \${fdt_addr} /boot/\${fdtfile}; \
 "
-UPDATEHUB_BOOTSCRIPT_LOAD_B_updatehub-imx_imx6qdlsabresd ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_B:updatehub-imx:imx6qdlsabresd ??= "\
 load mmc \${mmcdev}:3 \${loadaddr} /boot/\${image}; run findfdt; run video_args_script; \
 load mmc \${mmcdev}:3 \${fdt_addr} /boot/\${fdtfile}; \
 "
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A_updatehub-imx_imx6qdlsabresd ??= "part uuid mmc \${mmcdev}:2 uuid"
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B_updatehub-imx_imx6qdlsabresd ??= "part uuid mmc \${mmcdev}:3 uuid"
-UPDATEHUB_BOOTSCRIPT_BOOTARGS_updatehub-imx_imx6qdlsabresd ??= "\
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A:updatehub-imx:imx6qdlsabresd ??= "part uuid mmc \${mmcdev}:2 uuid"
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B:updatehub-imx:imx6qdlsabresd ??= "part uuid mmc \${mmcdev}:3 uuid"
+UPDATEHUB_BOOTSCRIPT_BOOTARGS:updatehub-imx:imx6qdlsabresd ??= "\
 root=PARTUUID=\${uuid} rootfstype=ext4 rootwait rw \
 console=\${console},\${baudrate} \${video_args} \
 "
-UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_imx6qdlsabresd ??= "bootz \${loadaddr} - \${fdt_addr}"
+UPDATEHUB_BOOTSCRIPT_BOOTCMD:updatehub-imx:imx6qdlsabresd ??= "bootz \${loadaddr} - \${fdt_addr}"
 
 
 
@@ -70,24 +70,24 @@ UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_imx6qdlsabresd ??= "bootz \${loadaddr
 # Configuration for i.MX6 Wandboard Quad/Dual/Solo
 #
 # UpdateHub settings for wandboard machine
-MACHINEOVERRIDES_prepend_wandboard = "updatehub-imx:"
-WKS_FILES_updatehub-imx_wandboard ??= "updatehub.imx-uboot-spl-bootpart.wks.in"
-IMAGE_BOOT_FILES_updatehub-imx_wandboard ??= "boot.scr-${MACHINE};boot.scr"
+MACHINEOVERRIDES:prepend:wandboard = "updatehub-imx:"
+WKS_FILES:updatehub-imx:wandboard ??= "updatehub.imx-uboot-spl-bootpart.wks.in"
+IMAGE_BOOT_FILES:updatehub-imx:wandboard ??= "boot.scr-${MACHINE};boot.scr"
 # UpdateHub Bootscript variables for wandboard machine
-UPDATEHUB_BOOTSCRIPT_LOAD_A_updatehub-imx_wandboard ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_A:updatehub-imx:wandboard ??= "\
 load mmc \${devnum}:2 \${loadaddr} /boot/${KERNEL_IMAGETYPE}; run findfdt; \
 load mmc \${devnum}:2 \${fdt_addr} /boot/\${fdtfile} \
 "
-UPDATEHUB_BOOTSCRIPT_LOAD_B_updatehub-imx_wandboard ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_B:updatehub-imx:wandboard ??= "\
 load mmc \${devnum}:3 \${loadaddr} /boot/${KERNEL_IMAGETYPE}; run findfdt; \
 load mmc \${devnum}:3 \${fdt_addr} /boot/\${fdtfile} \
 "
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A_updatehub-imx_wandboard ??= "part uuid mmc \${devnum}:2 uuid"
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B_updatehub-imx_wandboard ??= "part uuid mmc \${devnum}:3 uuid"
-UPDATEHUB_BOOTSCRIPT_BOOTARGS_updatehub-imx_wandboard ??= "\
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A:updatehub-imx:wandboard ??= "part uuid mmc \${devnum}:2 uuid"
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B:updatehub-imx:wandboard ??= "part uuid mmc \${devnum}:3 uuid"
+UPDATEHUB_BOOTSCRIPT_BOOTARGS:updatehub-imx:wandboard ??= "\
 console=\${console},\${baudrate} root=PARTUUID=\${uuid} rootwait rw \${video_args} \
 "
-UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_wandboard ??= "bootz \${loadaddr} - \${fdt_addr}"
+UPDATEHUB_BOOTSCRIPT_BOOTCMD:updatehub-imx:wandboard ??= "bootz \${loadaddr} - \${fdt_addr}"
 
 
 
@@ -95,11 +95,11 @@ UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_wandboard ??= "bootz \${loadaddr} - \
 # Configuration for Boundary Devices
 #
 # UpdateHub settings for nitrogen6x machine
-MACHINEOVERRIDES_prepend_nitrogen6x = "updatehub-imx:"
-WKS_FILES_updatehub-imx_nitrogen6x ??= "updatehub.imx.wks"
-PREFERRED_PROVIDER_virtual/bootloader_updatehub-imx_nitrogen6x ??= "u-boot-boundary"
-PREFERRED_RPROVIDER_u-boot-fw-utils_updatehub-imx_nitrogen6x ??= "u-boot-boundary-fw-utils"
-WKS_FILE_DEPENDS_updatehub-imx_nitrogen6x ??= "u-boot-script-boundary-updatehub"
+MACHINEOVERRIDES:prepend:nitrogen6x = "updatehub-imx:"
+WKS_FILES:updatehub-imx:nitrogen6x ??= "updatehub.imx.wks"
+PREFERRED_PROVIDER_virtual/bootloader:updatehub-imx:nitrogen6x ??= "u-boot-boundary"
+PREFERRED_RPROVIDER_u-boot-fw-utils:updatehub-imx:nitrogen6x ??= "u-boot-boundary-fw-utils"
+WKS_FILE_DEPENDS:updatehub-imx:nitrogen6x ??= "u-boot-script-boundary-updatehub"
 
 
 
@@ -107,88 +107,88 @@ WKS_FILE_DEPENDS_updatehub-imx_nitrogen6x ??= "u-boot-script-boundary-updatehub"
 # Configuration for Toradex machines
 #
 # UpdateHub settings for apalis-imx6 machine
-MACHINEOVERRIDES_prepend_apalis-imx6 = "updatehub-imx:"
-WKS_FILES_updatehub-imx_apalis-imx6 ??= "updatehub.imx.wks"
-UPDATEHUB_RUNTIME_PACKAGES_append_apalis-imx6 = " updatehub-config-toradex"
+MACHINEOVERRIDES:prepend:apalis-imx6 = "updatehub-imx:"
+WKS_FILES:updatehub-imx:apalis-imx6 ??= "updatehub.imx.wks"
+UPDATEHUB_RUNTIME_PACKAGES:append:apalis-imx6 = " updatehub-config-toradex"
 # UpdateHub Bootscript variables for apalis-imx6 machine
-UPDATEHUB_BOOTSCRIPT_LOAD_A_updatehub-imx_apalis-imx6 ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_A:updatehub-imx:apalis-imx6 ??= "\
 load mmc \${devnum}:2 \${fdt_addr_r} /boot/\${fdtfile};\
 load mmc \${devnum}:2 \${kernel_addr_r} /boot/${KERNEL_IMAGETYPE}; \
 "
-UPDATEHUB_BOOTSCRIPT_LOAD_B_updatehub-imx_apalis-imx6 ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_B:updatehub-imx:apalis-imx6 ??= "\
 load mmc \${devnum}:3 \${fdt_addr_r} /boot/\${fdtfile};\
 load mmc \${devnum}:3 \${kernel_addr_r} /boot/${KERNEL_IMAGETYPE}; \
 "
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A_updatehub-imx_apalis-imx6 ??= "part uuid mmc \${devnum}:2 uuid"
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B_updatehub-imx_apalis-imx6 ??= "part uuid mmc \${devnum}:3 uuid"
-UPDATEHUB_BOOTSCRIPT_BOOTARGS_updatehub-imx_apalis-imx6 ??= "\
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A:updatehub-imx:apalis-imx6 ??= "part uuid mmc \${devnum}:2 uuid"
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B:updatehub-imx:apalis-imx6 ??= "part uuid mmc \${devnum}:3 uuid"
+UPDATEHUB_BOOTSCRIPT_BOOTARGS:updatehub-imx:apalis-imx6 ??= "\
 console=\${console},\${baudrate} root=PARTUUID=\${uuid} rw rootfstype=ext4 rootwait \${defargs} \${vidargs}\
 "
-UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_apalis-imx6 ??= "bootz \${kernel_addr_r} - \${fdt_addr_r}"
+UPDATEHUB_BOOTSCRIPT_BOOTCMD:updatehub-imx:apalis-imx6 ??= "bootz \${kernel_addr_r} - \${fdt_addr_r}"
 
 
 # UpdateHub settings for colibri-imx6 machine
-MACHINEOVERRIDES_prepend_colibri-imx6 = "updatehub-imx:"
-WKS_FILES_updatehub-imx_colibri-imx6 ??= "updatehub.imx.wks"
-UPDATEHUB_RUNTIME_PACKAGES_append_colibri-imx6 = " updatehub-config-toradex"
+MACHINEOVERRIDES:prepend:colibri-imx6 = "updatehub-imx:"
+WKS_FILES:updatehub-imx:colibri-imx6 ??= "updatehub.imx.wks"
+UPDATEHUB_RUNTIME_PACKAGES:append:colibri-imx6 = " updatehub-config-toradex"
 # UpdateHub Bootscript variables for colibri-imx6 machine
-UPDATEHUB_BOOTSCRIPT_LOAD_A_updatehub-imx_colibri-imx6 ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_A:updatehub-imx:colibri-imx6 ??= "\
 load mmc \${devnum}:2 \${fdt_addr_r} /boot/\${fdtfile}; \
 load mmc \${devnum}:2 \${kernel_addr_r} /boot/${KERNEL_IMAGETYPE} \
 "
-UPDATEHUB_BOOTSCRIPT_LOAD_B_updatehub-imx_colibri-imx6 ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_B:updatehub-imx:colibri-imx6 ??= "\
 load mmc \${devnum}:3 \${fdt_addr_r} /boot/\${fdtfile}; \
 load mmc \${devnum}:3 \${kernel_addr_r} /boot/${KERNEL_IMAGETYPE} \
 "
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A_updatehub-imx_colibri-imx6 ??= "part uuid mmc \${devnum}:2 uuid"
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B_updatehub-imx_colibri-imx6 ??= "part uuid mmc \${devnum}:3 uuid"
-UPDATEHUB_BOOTSCRIPT_BOOTARGS_updatehub-imx_colibri-imx6 ??= "\
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A:updatehub-imx:colibri-imx6 ??= "part uuid mmc \${devnum}:2 uuid"
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B:updatehub-imx:colibri-imx6 ??= "part uuid mmc \${devnum}:3 uuid"
+UPDATEHUB_BOOTSCRIPT_BOOTARGS:updatehub-imx:colibri-imx6 ??= "\
 console=\${console},\${baudrate} root=PARTUUID=\${uuid} rw rootfstype=ext4 rootwait \${defargs} \${vidargs} \
 "
-UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_colibri-imx6 ??= "bootz \${kernel_addr_r} - \${fdt_addr_r}"
+UPDATEHUB_BOOTSCRIPT_BOOTCMD:updatehub-imx:colibri-imx6 ??= "bootz \${kernel_addr_r} - \${fdt_addr_r}"
 
 
 # UpdateHub settings for colibri-imx7-emmc machine
-MACHINEOVERRIDES_prepend_colibri-imx7-emmc = "updatehub-imx:"
-WKS_FILES_updatehub-imx_colibri-imx7-emmc ??= "updatehub.imx.wks"
-UPDATEHUB_RUNTIME_PACKAGES_append_colibri-imx7-emmc = " updatehub-config-toradex"
+MACHINEOVERRIDES:prepend:colibri-imx7-emmc = "updatehub-imx:"
+WKS_FILES:updatehub-imx:colibri-imx7-emmc ??= "updatehub.imx.wks"
+UPDATEHUB_RUNTIME_PACKAGES:append:colibri-imx7-emmc = " updatehub-config-toradex"
 # UpdateHub Bootscript variables for colibri-imx7-emmc machine
-UPDATEHUB_BOOTSCRIPT_LOAD_A_updatehub-imx_colibri-imx7-emmc ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_A:updatehub-imx:colibri-imx7-emmc ??= "\
 load mmc \${devnum}:2 \${fdt_addr_r} /boot/\${fdtfile}; \
 load mmc \${devnum}:2 \${kernel_addr_r} /boot/${KERNEL_IMAGETYPE} \
 "
-UPDATEHUB_BOOTSCRIPT_LOAD_B_updatehub-imx_colibri-imx7-emmc ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_B:updatehub-imx:colibri-imx7-emmc ??= "\
 load mmc \${devnum}:3 \${fdt_addr_r} /boot/\${fdtfile}; \
 load mmc \${devnum}:3 \${kernel_addr_r} /boot/${KERNEL_IMAGETYPE} \
 "
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A_updatehub-imx_colibri-imx7-emmc ??= "part uuid mmc \${devnum}:2 uuid"
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B_updatehub-imx_colibri-imx7-emmc ??= "part uuid mmc \${devnum}:3 uuid"
-UPDATEHUB_BOOTSCRIPT_BOOTARGS_updatehub-imx_colibri-imx7-emmc ??= "\
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A:updatehub-imx:colibri-imx7-emmc ??= "part uuid mmc \${devnum}:2 uuid"
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B:updatehub-imx:colibri-imx7-emmc ??= "part uuid mmc \${devnum}:3 uuid"
+UPDATEHUB_BOOTSCRIPT_BOOTARGS:updatehub-imx:colibri-imx7-emmc ??= "\
 console=\${console},\${baudrate} root=PARTUUID=\${uuid} rw rootfstype=ext4 rootwait \${defargs} \${vidargs} \
 "
-UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_colibri-imx7-emmc ??= "bootz \${kernel_addr_r} - \${fdt_addr_r}"
+UPDATEHUB_BOOTSCRIPT_BOOTCMD:updatehub-imx:colibri-imx7-emmc ??= "bootz \${kernel_addr_r} - \${fdt_addr_r}"
 
 
 
 ###
 # Configuration for TechNexion/NXP devices
 #
-MACHINEOVERRIDES_prepend_imx7d-pico = "updatehub-imx:"
-WKS_FILES_updatehub-imx_imx7d-pico ??= "updatehub.imx-uboot-spl-bootpart.wks.in"
-IMAGE_BOOT_FILES_updatehub-imx_imx7d-pico ??= "boot.scr-${MACHINE};boot.scr"
+MACHINEOVERRIDES:prepend:imx7d-pico = "updatehub-imx:"
+WKS_FILES:updatehub-imx:imx7d-pico ??= "updatehub.imx-uboot-spl-bootpart.wks.in"
+IMAGE_BOOT_FILES:updatehub-imx:imx7d-pico ??= "boot.scr-${MACHINE};boot.scr"
 # UpdateHub Bootscript variables for imx7d-pico machine
-UPDATEHUB_BOOTSCRIPT_LOAD_A_updatehub-imx_imx7d-pico ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_A:updatehub-imx:imx7d-pico ??= "\
 load mmc \${mmcdev}:2 \${loadaddr} /boot/\${image}; run findfdt; run video_args_script; \
 load mmc \${mmcdev}:2 \${fdt_addr} /boot/\${fdtfile}; \
 "
-UPDATEHUB_BOOTSCRIPT_LOAD_B_updatehub-imx_imx7d-pico ??= "\
+UPDATEHUB_BOOTSCRIPT_LOAD_B:updatehub-imx:imx7d-pico ??= "\
 load mmc \${mmcdev}:3 \${loadaddr} /boot/\${image}; run findfdt; run video_args_script; \
 load mmc \${mmcdev}:3 \${fdt_addr} /boot/\${fdtfile}; \
 "
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A_updatehub-imx_imx7d-pico ??= "part uuid mmc \${mmcdev}:2 uuid"
-UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B_updatehub-imx_imx7d-pico ??= "part uuid mmc \${mmcdev}:3 uuid"
-UPDATEHUB_BOOTSCRIPT_BOOTARGS_updatehub-imx_imx7d-pico ??= "\
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A:updatehub-imx:imx7d-pico ??= "part uuid mmc \${mmcdev}:2 uuid"
+UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B:updatehub-imx:imx7d-pico ??= "part uuid mmc \${mmcdev}:3 uuid"
+UPDATEHUB_BOOTSCRIPT_BOOTARGS:updatehub-imx:imx7d-pico ??= "\
 root=PARTUUID=\${uuid} rootfstype=ext4 rootwait rw \
 console=\${console},\${baudrate} \${video_args} \
 "
-UPDATEHUB_BOOTSCRIPT_BOOTCMD_updatehub-imx_imx7d-pico ??= "bootz \${loadaddr} - \${fdt_addr}"
+UPDATEHUB_BOOTSCRIPT_BOOTCMD:updatehub-imx:imx7d-pico ??= "bootz \${loadaddr} - \${fdt_addr}"

--- a/recipes-bsp/u-boot/u-boot-fslc/imx6qdlsabresd/fw_env.config
+++ b/recipes-bsp/u-boot/u-boot-fslc/imx6qdlsabresd/fw_env.config
@@ -1,1 +1,1 @@
-/dev/mmcblk1            0xc0000         0x2000
+/dev/mmcblk2            0xc0000         0x2000

--- a/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
@@ -1,8 +1,8 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 UPDATEHUB_IMX_PATCHES = "\
     file://fw_env.config \
     file://updatehub.cfg \
 "
 
-SRC_URI_append_updatehub-imx = " ${UPDATEHUB_IMX_PATCHES}"
+SRC_URI:append:updatehub-imx = " ${UPDATEHUB_IMX_PATCHES}"

--- a/recipes-bsp/u-boot/u-boot-script-boundary-updatehub.bb
+++ b/recipes-bsp/u-boot/u-boot-script-boundary-updatehub.bb
@@ -30,10 +30,10 @@ do_deploy () {
 
 addtask deploy after do_install before do_build
 
-FILES_${PN} += "/"
+FILES:${PN} += "/"
 
 PROVIDES += "u-boot-default-script"
-RPROVIDES_${PN} += "u-boot-default-script"
+RPROVIDES:${PN} += "u-boot-default-script"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(nitrogen6x|nitrogen6x-lite|nitrogen6sx|nitrogen7)"

--- a/recipes-bsp/u-boot/u-boot-toradex_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-toradex_%.bbappend
@@ -1,8 +1,8 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 UPDATEHUB_IMX_PATCHES = "\
     file://fw_env.config \
     file://updatehub.cfg \
 "
 
-SRC_URI_append_updatehub-imx = " ${UPDATEHUB_IMX_PATCHES}"
+SRC_URI:append:updatehub-imx = " ${UPDATEHUB_IMX_PATCHES}"

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,3 +1,3 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-dirs755_append_updatehub-imx = " /data"
+dirs755:append:updatehub-imx = " /data"

--- a/recipes-core/updatehub/updatehub-config-toradex.bb
+++ b/recipes-core/updatehub/updatehub-config-toradex.bb
@@ -12,7 +12,7 @@ do_install() {
     install -Dm 0755 ${WORKDIR}/unlock_emmc ${D}${datadir}/updatehub/state-change-callbacks.d/unlock_emmc
 }
 
-FILES_${PN} += "${datadir}/updatehub/state-change-callbacks.d/unlock_emmc"
+FILES:${PN} += "${datadir}/updatehub/state-change-callbacks.d/unlock_emmc"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "(apalis-imx6|colibri-imx6|colibri-imx7-emmc)"

--- a/uhu/imx6qdlsabresd.uhupkg.config
+++ b/uhu/imx6qdlsabresd.uhupkg.config
@@ -20,7 +20,7 @@
                 "mode": "raw",
                 "seek": 2,
                 "skip": 0,
-                "target": "/dev/disk/by-path/platform-2198000.usdhc",
+                "target": "/dev/disk/by-path/platform-2198000.mmc",
                 "target-type": "device",
                 "truncate": false
             },
@@ -33,7 +33,7 @@
                 "mode": "raw",
                 "seek": 69,
                 "skip": 0,
-                "target": "/dev/disk/by-path/platform-2198000.usdhc",
+                "target": "/dev/disk/by-path/platform-2198000.mmc",
                 "target-type": "device",
                 "truncate": false
             },
@@ -68,7 +68,7 @@
                 "mode": "raw",
                 "seek": 2,
                 "skip": 0,
-                "target": "/dev/disk/by-path/platform-2198000.usdhc",
+                "target": "/dev/disk/by-path/platform-2198000.mmc",
                 "target-type": "device",
                 "truncate": false
             },
@@ -81,7 +81,7 @@
                 "mode": "raw",
                 "seek": 69,
                 "skip": 0,
-                "target": "/dev/disk/by-path/platform-2198000.usdhc",
+                "target": "/dev/disk/by-path/platform-2198000.mmc",
                 "target-type": "device",
                 "truncate": false
             },


### PR DESCRIPTION
fef289d uhu/imx6qdlsabresd.uhupkg: Update target path
149fc07 u-boot-fslc: Fix fw_env.config for imx6qdlsabresd
0ef8ed9 Run convert-overrides.py against the layer
8fa162f conf/layer.conf: Support only honister release