### PR TITLE
layer.conf: Append WKS_FILE_DEPENDS at the end of parse instead of immediately

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,7 +18,7 @@ LAYERDEPENDS:updatehub-freescale = "updatehub"
 #
 # Setting to use wic image
 IMAGE_BOOT_FILES:updatehub-imx ??= ""
-WKS_FILE_DEPENDS:updatehub-imx += "virtual/bootloader"
+WKS_FILE_DEPENDS:append:updatehub-imx = " virtual/bootloader"
 IMAGE_FSTYPES:updatehub-imx ??= "tar.xz wic.bmap wic.gz"
 WKS_SEARCH_PATH:updatehub-imx ??= "${THISDIR}:${@':'.join('%s/wic' % p for p in '${BBPATH}'.split(':'))}:${@':'.join('%s/scripts/lib/wic/canned-wks' % l for l in '${BBPATH}:${COREBASE}'.split(':'))}"
 


### PR DESCRIPTION
It solves the following error:
"A native program mkfs.ext4 required to build the image was not found"

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>